### PR TITLE
Restrict public access to documentation

### DIFF
--- a/app/(root)/documentation/[...slug]/page.tsx
+++ b/app/(root)/documentation/[...slug]/page.tsx
@@ -35,18 +35,6 @@ export async function generateMetadata({
   };
 }
 
-export async function generateStaticParams() {
-  const paths: { slug: string[] }[] = [];
-  for (const section of docSections) {
-    if (section.children) {
-      for (const page of section.children) {
-        paths.push({ slug: [section.slug, page.slug] });
-      }
-    }
-  }
-  return paths;
-}
-
 export default async function DocCatchAllPage({ params }: DocPageProps) {
   const { slug } = await params;
 

--- a/app/(root)/documentation/layout.tsx
+++ b/app/(root)/documentation/layout.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+
+export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
   title: {
@@ -19,10 +23,21 @@ export const metadata: Metadata = {
   },
 };
 
-export default function DocumentationLayout({
+export default async function DocumentationLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const role = session.user.role;
+  if (role !== "TESTER" && role !== "SUPERIOR") {
+    redirect("/courses");
+  }
+
   return children;
 }


### PR DESCRIPTION
This pull request introduces authentication and authorization checks to the documentation pages, ensuring only users with the appropriate roles can access them. It also removes the static parameters generation for documentation routes, likely in favor of dynamic routing.

**Authentication and Authorization:**
* [`app/(root)/documentation/layout.tsx`](diffhunk://#diff-8925880b10ccd375af0b13b3387cc2df58b04d839d6a8d7529baf5befa2887e6R2-R5): Added authentication using `auth()` and redirects users to `/login` if not authenticated, or to `/courses` if their role is not `TESTER` or `SUPERIOR`. The layout is now an async function to support these checks. [[1]](diffhunk://#diff-8925880b10ccd375af0b13b3387cc2df58b04d839d6a8d7529baf5befa2887e6R2-R5) [[2]](diffhunk://#diff-8925880b10ccd375af0b13b3387cc2df58b04d839d6a8d7529baf5befa2887e6L22-R41)
* [`app/(root)/documentation/layout.tsx`](diffhunk://#diff-8925880b10ccd375af0b13b3387cc2df58b04d839d6a8d7529baf5befa2887e6R2-R5): Set `export const dynamic = "force-dynamic";` to ensure the layout is rendered dynamically, supporting the authentication logic.

**Routing and Static Parameters:**
* `app/(root)/documentation/[...slug]/page.tsx`: Removed the `generateStaticParams` function, indicating a shift from static to dynamic route handling for documentation pages. ([app/(root)/documentation/[...slug]/page.tsxL38-L49](diffhunk://#diff-228ad952637481877bd013c9deffa5ba865f1649fd21620716b14a1ecc68a805L38-L49))