### PR TITLE
Remove IP allowlist restriction from integration authentication

### DIFF
--- a/lib/integration-auth.ts
+++ b/lib/integration-auth.ts
@@ -68,11 +68,4 @@ export function assertIntegrationAccess(req: NextRequest) {
     throw new IntegrationAuthError("Invalid integration key.", 401);
   }
 
-  const allowlist = parseAllowlist(process.env.MAILING_SYNC_ALLOWED_IPS);
-  if (allowlist.length > 0) {
-    const clientIp = getClientIp(req);
-    if (!allowlist.includes(clientIp)) {
-      throw new IntegrationAuthError("IP is not allowed.", 403);
-    }
-  }
 }


### PR DESCRIPTION
This pull request removes the IP allowlist check from the `assertIntegrationAccess` function in `lib/integration-auth.ts`. Previously, requests were only allowed if their IP was in the configured allowlist; this restriction has now been lifted.

Authentication logic update:

* Removed the IP allowlist check from `assertIntegrationAccess`, so access is no longer restricted based on client IP addresses.